### PR TITLE
write the central directory forward

### DIFF
--- a/src/zipc.ml
+++ b/src/zipc.ml
@@ -572,7 +572,7 @@ let write_bytes ?(first = default_first) z ?(start = 0) b =
       let acc = encode_member b m (start, []) in
       fold (encode_member b) (remove first z) acc
   in
-  let eocd_start = List.fold_left (encode_cd_member b) cd_start ms in
+  let eocd_start = List.fold_left (encode_cd_member b) cd_start (List.rev ms) in
   let cd_size = eocd_start - cd_start in
   encode_eocd b eocd_start ~member_count:count ~cd_start ~cd_size
 


### PR DESCRIPTION
Currently, the files contents are in lexicographic order, but the filenames in the central directory are in reverse-lexicographic order.

I found this because MS word thought .docx files created by this library are suspicious (it prompts the user, but can read the file just fine if you proceed), and I thought that the odd ordering could trigger heuristics for "this looks like a zip-bomb".

I have lost track of whether this helps or not, but this is better regardless.